### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         #torch-version: ["1.5.0", "1.4.0"]
 
     steps:


### PR DESCRIPTION
Due to conflicts in dependencies, I think it is best to drop support for python 3.6. We continue to officially support python 3.7 and 3.8. 